### PR TITLE
Fix link to markdown guide.

### DIFF
--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -26,7 +26,7 @@ class Speaker(models.Model):
                                         " conference program."))
     biography = models.TextField(blank=True, help_text=_("A little bit about you.  Edit using "
                                                          "<a href='http://warpedvisions.org/projects/"
-                                                         "markdown-cheat-sheet/target='_blank'>"
+                                                         "markdown-cheat-sheet/' target='_blank'>"
                                                          "Markdown</a>."), verbose_name=_("Biography"))
     biography_html = models.TextField(blank=True)
     photo = models.ImageField(upload_to="speaker_photos", blank=True, verbose_name=_("Photo"))


### PR DESCRIPTION
Previous link was missing `' `, causing the `target=` directive to get appended to the URL.